### PR TITLE
Smooth scrolling on example20

### DIFF
--- a/example20/main.c
+++ b/example20/main.c
@@ -22,21 +22,39 @@ typedef struct {
   uint8_t data[];
 } level_t;
 
+typedef struct {
+  uint16_t grid_x;
+  uint16_t grid_y;
+} tile_t;
+
 extern level_t egyptLevel;
 
 extern phrase black;
 
-#define WIDTH 256
+#define WIDTH 320
 #define HEIGHT 192
 
-#define TILES_W 16
-#define TILES_H 16
-
-#define TILES_PER_LINE (320 / TILES_W)
+#define TILES_PER_LINE (320 / 16)
+#define NUM_TILES (TILES_PER_LINE * 192 / 16)
 
 #include <console.h>
 
 #define SWAP(typ, v1, v2) { typ tmp = v1; v1 = v2; v2 = tmp; }
+
+tile_t *tile_data;
+int map_x;
+
+void init_map(void)
+{
+  int i;
+
+  tile_data = (tile_t *) malloc(sizeof(tile_t) * NUM_TILES);
+
+  for (i = 0; i < NUM_TILES; i++) {
+    tile_data[i].grid_x = (i % TILES_PER_LINE) * 16;
+    tile_data[i].grid_y = (i / TILES_PER_LINE) * 16;
+  }
+}
 
 void copy_column(screen *tiles, screen *tgt, level_t *lvl, int lrow, int hrow, int colno) {
   uint16_t nrows = lvl->nrows;
@@ -44,10 +62,11 @@ void copy_column(screen *tiles, screen *tgt, level_t *lvl, int lrow, int hrow, i
   int i;
   for(i = lrow; i < hrow; i++) {
     int tileno = data[i];
-    tiles->x = (tileno % TILES_PER_LINE) * TILES_W;
-    tiles->y = (tileno / TILES_PER_LINE) * TILES_H;
-    screen_copy_straight(tiles, tgt, TILES_W, TILES_H, MODE_S);
-    tgt->y += TILES_H;
+    tile_t *tile = &tile_data[tileno];
+    tiles->x = tile->grid_x;
+    tiles->y = tile->grid_y;
+    screen_copy_straight(tiles, tgt, 16, 16, MODE_S);
+    tgt->y += 16;
   }
 }
 
@@ -57,7 +76,7 @@ void copy_zone(screen *tiles, screen *tgt, level_t *lvl, int x, int y, int lrow,
   for(i = lcol; i < hcol; i++) {
     tgt->y = y;
     copy_column(tiles, tgt, lvl, lrow, hrow, i);
-    tgt->x += TILES_W;
+    tgt->x += 16;
   }
 }
 
@@ -68,7 +87,7 @@ int main(int argc, char *argv[]) {
 
   display *d = new_display(0);
 
-  d->x = 64;
+  d->x = 20;
   d->y = 16;
 
   memcpy((void*)TOMREGS->clut1, egyptPal, NCOLS*sizeof(uint16_t));
@@ -84,24 +103,32 @@ int main(int argc, char *argv[]) {
   phrase *screen1_data = alloc_simple_screen(DEPTH8, WIDTH, HEIGHT, screen1);
   phrase *screen2_data = alloc_simple_screen(DEPTH8, WIDTH, HEIGHT, screen2);
 
-  sprite *screen1_sprite = sprite_of_screen(0, 0, screen1);
-  sprite *screen2_sprite = sprite_of_screen(WIDTH, 0, screen2);
+  map_x = 0;
+  sprite *screen1_sprite = sprite_of_screen(-map_x, 0, screen1);
+  sprite *screen2_sprite = sprite_of_screen(-map_x + WIDTH, 0, screen2);
   screen1_sprite->trans = 0;
   screen2_sprite->trans = 0;
 
-  sprite *black_border = new_sprite(16, 1, -16, 0, DEPTH16, &black);
-  black_border->trans = 0;
-  black_border->dwidth = 0;
-  black_border->height = HEIGHT;
+  //sprite *black_border = new_sprite(16, 1, -16, 0, DEPTH16, &black);
+  //black_border->trans = 0;
+  //black_border->dwidth = 0;
+  //black_border->height = HEIGHT;
 
   clear_screen(screen1);
   clear_screen(screen2);
 
+  screen *scr1 = screen1;
+  screen *scr2 = screen2;
+  sprite *spr1 = screen1_sprite;
+  sprite *spr2 = screen2_sprite;
+
   attach_sprite_to_display_at_layer(screen1_sprite, d, 0);
   attach_sprite_to_display_at_layer(screen2_sprite, d, 0);
-  attach_sprite_to_display_at_layer(black_border, d, 1);
+  //attach_sprite_to_display_at_layer(black_border, d, 1);
 
-  copy_zone(tiles, screen1, &egyptLevel, 0, 0, 0, HEIGHT/TILES_H, 0, WIDTH/TILES_W);
+  init_map();
+  copy_zone(tiles, scr1, &egyptLevel, 0, 0, 0, HEIGHT/16, 0, WIDTH/16);
+  copy_zone(tiles, scr2, &egyptLevel, 0, 0, 0, HEIGHT/16, WIDTH/16 + 1, WIDTH/16 + 2);
 
   show_display(d);
 
@@ -116,11 +143,38 @@ int main(int argc, char *argv[]) {
     unsigned long cmd = joypads.j1;
 
     if(cmd & JOYPAD_RIGHT) {
-      screen1_sprite->x--;
-      screen2_sprite->x--;
-    } else if(cmd & JOYPAD_LEFT) {
-      screen1_sprite->x++;
-      screen2_sprite->x++;
+      map_x++;
+
+      if (spr1->x < -WIDTH) {
+        spr1->x += WIDTH << 1;
+
+        screen *tmp_scr = scr1;
+        scr1 = scr2;
+        scr2 = tmp_scr;
+
+        sprite *tmp_spr = spr1;
+        spr1 = spr2;
+        spr2 = tmp_spr;
+      }
+
+      spr1->x--;
+      spr2->x--;
+
+      if (map_x & 15) {
+        int map_tx = map_x >> 4;
+        copy_zone(tiles, scr2, &egyptLevel, map_tx << 4, 0, 0, HEIGHT/16, WIDTH/16 + 1 + map_tx, WIDTH/16 + 2 + map_tx);
+      }
     }
+
+    wait_display_refresh();
   }
+
+  free(screen1_sprite);
+  free(screen1_data);
+  free(screen1);
+  free(screen2_sprite);
+  free(screen2_data);
+  free(screen2);
+  free(tiles);
+  free(tile_data);
 }


### PR DESCRIPTION
Smooth scrolling by only drawing one new column when needed.
Note that the tile size is hard coded to 16x16 now in order to optimize some calclulations.